### PR TITLE
Add migration script for rsa isolement

### DIFF
--- a/migrations/rsa-isolement.js
+++ b/migrations/rsa-isolement.js
@@ -1,0 +1,40 @@
+var mongoose = require('mongoose');
+var es = require('event-stream');
+var config = require('../lib/config/config');
+var _ = require('lodash');
+
+require('../lib/config/mongoose')(mongoose, config);
+
+var Situation = mongoose.model('Situation');
+
+Situation.find({ status: 'test' }).stream()
+    .pipe(es.map(function (situation, done) {
+
+        var isSituationUpdated = false;
+        hasConjoint = _.find(situation.individus, { role: 'conjoint' });
+        hasEnfant = _.find(situation.individus, { role: 'enfant' });
+
+        if (hasEnfant && ! hasConjoint) {
+            situation.individus[0].isolementRecent = true;
+            isSituationUpdated = true;
+        }
+
+        situation.save(function (err) {
+            if (err) {
+                console.log('Cannot save migrated situation %s', situation.id);
+                console.trace(err);
+            }
+            else if (isSituationUpdated)
+                console.log('Situation migrée');
+            done();
+        });
+    }))
+    .on('end', function() {
+        console.log('Terminé');
+        process.exit();
+    })
+    .on('error', function(err) {
+        console.trace(err);
+        process.exit();
+    })
+    .resume();


### PR DESCRIPTION
In most of our tests with single parents, we are supposed to get RSA majoré. Since we tightened the conditions (you need to have been single for less than 18 months), these tests are now broken. This script will set all these tests `isolementRecent` property to be true. 