### PR TITLE
Fixup api

### DIFF
--- a/lib/simulation/openfisca/mapping/index.js
+++ b/lib/simulation/openfisca/mapping/index.js
@@ -200,7 +200,6 @@ var mapFamille = function(situation) {
         ressources = ressources.concat(individu.ressources);
     });
     applyRessources({ ressources: ressources }, famille, ressourcesMap.famille, situation);
-    setNonInjectedPrestationsToZero(famille, situation.dateDeValeur);
 
     return famille;
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sgmap-mes-aides-api",
   "description": "mes-aides.gouv.fr REST API",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
The `setNonInjectedPrestationsToZero` call should have been removed from `mapFamille` in `aah` feature branch. 
This was not detected before because it has no consequence when you run a simulation. It would mess up the ludwig tests by injecting zeroed prestations at a wrong time. More precisely, dateDeValeur was undefined in the call with only 2 parameters and thus it was using today's date.

The core problem is that running all ludwig tests is still super slow and tedious, so I can't afford to do it all the time. Maybe I should try to make sure I run them before merging `mes-aides-api`, instead of before merging `mes-aides-ui`