### PR TITLE
Autoriser l'obtention d'une simulation d'après son ID

### DIFF
--- a/lib/routes/situations.js
+++ b/lib/routes/situations.js
@@ -10,12 +10,6 @@ module.exports = function(api) {
     /*
     ** Security
     */
-    var allowShow = function(req, res, next) {
-        var situation = req.situation;
-        if (req.situation.status === 'test' || req.cookies['situation_' + situation.id] === situation.token) return next();
-        res.status(403).end();
-    };
-
     var allowUpdate = function(req, res, next) {
         var situation = req.situation;
         if (req.cookies['situation_' + situation.id] === situation.token || (situation.status === 'test' && req.isAuthenticated())) return next();
@@ -26,7 +20,7 @@ module.exports = function(api) {
     ** Routes
     */
     api.route('/situations/:situationId')
-        .get(allowShow, situations.show)
+        .get(situations.show)
         .put(allowUpdate, situations.update);
 
     api.route('/situations').post(situations.create);
@@ -35,8 +29,8 @@ module.exports = function(api) {
 
     api.route('/situations/:situationId/simulation').get(situations.simulation);
 
-    api.route('/situations/:situationId/openfisca-response').get(allowShow, situations.openfiscaResponse);
+    api.route('/situations/:situationId/openfisca-response').get(situations.openfiscaResponse);
 
-    api.route('/situations/:situationId/openfisca-request').get(allowShow, situations.openfiscaRequest);
+    api.route('/situations/:situationId/openfisca-request').get(situations.openfiscaRequest);
 
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sgmap-mes-aides-api",
   "description": "mes-aides.gouv.fr REST API",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Permet de retrouver une simulation à partir de son ID via `https://mes-aides.gouv.fr/foyer/resultat?situationId=xxx`

Pour vérifier en local que ça fonctionne : 
- Créer une simulation dans une fenêtre
- Obtenir l'ID en déclarant un écart de droit
- Tester `localhost:9000/foyer/resultat?situationId=xxx` en navigation privée.