### PR TITLE
Ajout d'un script pour rendre les situations temporairement visibles

### DIFF
--- a/migrations/migrations.js
+++ b/migrations/migrations.js
@@ -30,6 +30,15 @@ function migrateAllSituations(migrationFunction) {
         .resume();
 }
 
+function setSituationVisibility(situationId, visibility, callback) {
+    if (visibility) {
+       Situation.findById(situationId).update({}, { status: 'test' }).exec(callback);
+    } else {
+        Situation.findById(situationId).update({}, { status: 'new' }).exec(callback);
+    }
+}
+
 module.exports = {
-    migrateAllSituations: migrateAllSituations
+    migrateAllSituations: migrateAllSituations,
+    setSituationVisibility: setSituationVisibility
 }

--- a/migrations/setSituationVisibility.js
+++ b/migrations/setSituationVisibility.js
@@ -1,0 +1,10 @@
+setSituationVisibility = require('./migrations').setSituationVisibility;
+
+var situationId = process.argv[2];
+
+// Make the situation non visible only if a "false" additional argument have been passed
+var visibility = process.argv.length <= 3 || process.argv[3] != "false";
+
+setSituationVisibility(situationId, visibility, function() {
+    process.exit();
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sgmap-mes-aides-api",
   "description": "mes-aides.gouv.fr REST API",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Usage par script : 
```sh
# Rend la situation publique (accessible à qui connaît son id)
ssh yyy@mes-aides.gouv.fr "node /home/deploy/setSituationVisibility.js 58a4823xxxxx9ac3b9"  
```

# Rend la situation privée
```
ssh yyy@mes-aides.gouv.fr "node /home/deploy/setSituationVisibility.js 58a4823xxxxx9ac3b9 false"  
```

Sous réserve d'avoir fait un symlink depuis le répertoire contenant les sources vers `/home/deploy/setSituationVisibility.js`