### PR TITLE
Stop relying on deprecated method to send HTML status back

### DIFF
--- a/lib/config/api.js
+++ b/lib/config/api.js
@@ -16,7 +16,7 @@ function createApi() {
     });
 
     api.all('*', function(req, res) {
-        res.send(404);
+        res.sendStatus(404);
     });
 
     return api;

--- a/lib/controllers/situations.js
+++ b/lib/controllers/situations.js
@@ -10,6 +10,7 @@ exports.situation = function(req, res, next, id) {
     Situation.findById(id, function(err, situation) {
         if (err) return next(err);
         if (!situation) return res.sendStatus(404);
+
         req.situation = situation;
         next();
     });
@@ -25,6 +26,7 @@ exports.update = function(req, res, next) {
         .set(_.omit(req.body, 'status', 'token'))
         .save(function(err) {
             if (err) return next(err);
+
             res.send(req.situation);
         });
 };
@@ -32,6 +34,7 @@ exports.update = function(req, res, next) {
 exports.submit = function(req, res, next) {
     req.situation.submit(function(err) {
         if (err) return next(err);
+
         res.send(req.situation);
     });
 };
@@ -39,14 +42,17 @@ exports.submit = function(req, res, next) {
 exports.create = function(req, res, next) {
     Situation.create(_.omit(req.body, 'status', 'token'), function(err, situation) {
         if (err) return next(err);
-        res.cookie('situation_' + situation.id, situation.token, { maxAge: 7 * 24 * 3600 * 1000, httpOnly: true });
+
+        var cookieParams = { maxAge: 7 * 24 * 3600 * 1000, httpOnly: true };
+        res.cookie('situation_' + situation.id, situation.token, cookieParams);
         res.send(situation);
     });
 };
 
-exports.simulation = function(req, res) {
+exports.simulation = function(req, res, next) {
     req.situation.simulate(function(err, result) {
-        if (err) return res.status(err.code || 500).send(err);
+        if (err) return next(err);
+
         res.send(result);
     });
 };
@@ -58,6 +64,7 @@ exports.openfiscaRequest = function(req, res) {
 exports.openfiscaResponse = function(req, res, next) {
     openfisca.calculate(req.situation, true, function(err, result) {
         if (err) return next(err);
+
         res.send(result);
     });
 };

--- a/lib/controllers/situations.js
+++ b/lib/controllers/situations.js
@@ -60,7 +60,7 @@ exports.openfiscaRequest = function(req, res) {
 
 exports.openfiscaResponse = function(req, res, next) {
     openfisca.calculate(req.situation, true, function(err, result) {
-        if (err) next(err);
+        if (err) return next(err);
         res.send(result);
     });
 };

--- a/lib/controllers/situations.js
+++ b/lib/controllers/situations.js
@@ -9,7 +9,7 @@ var Situation = mongoose.model('Situation');
 exports.situation = function(req, res, next, id) {
     Situation.findById(id, function(err, situation) {
         if (err) return next(err);
-        if (!situation) return res.send(404);
+        if (!situation) return res.sendStatus(404);
         req.situation = situation;
         next();
     });

--- a/lib/controllers/situations.js
+++ b/lib/controllers/situations.js
@@ -46,11 +46,8 @@ exports.create = function(req, res, next) {
 
 exports.simulation = function(req, res) {
     req.situation.simulate(function(err, result) {
-        if (err) {
-            res.status(err.code || 500).send(err);
-        } else {
-            res.send(result);
-        }
+        if (err) return res.status(err.code || 500).send(err);
+        res.send(result);
     });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sgmap-mes-aides-api",
   "description": "mes-aides.gouv.fr REST API",
-  "version": "9.0.0",
+  "version": "9.0.1",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Remove this warning from server logs:
```bash
express deprecated res.send(status): Use res.sendStatus(status) instead node_modules/sgmap-mes-aides-api/lib/controllers/situations.js:12:36
```