### PR TITLE
Make sure tests fail when OpenFisca returns an error

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,15 @@ app.use(ludwigApi({
             if (err) return done(err);
             if (!situation) return done(new Error('Situation not found'));
             situation.simulate(function(err, result) {
-                return done(err, result && reverseMap(result, situation).calculatedPrestations);
+                if (! err) {
+                    return done(err, result && reverseMap(result, situation).calculatedPrestations);
+                }
+                console.error(err);
+                var bogusResult = {};
+                acceptanceTest.expectedResults.forEach(function(expectedResult) {
+                    bogusResult[expectedResult.code] = 'ERROR!' + expectedResult.expectedValue;
+                });
+                return done(null, bogusResult);
             });
         });
     },


### PR DESCRIPTION
Previously when Openfisca failed, that result was not persisted in the DB.

The failure was visible in the UI but after a page refreshes it was no longer available.

That change is a hack to help during the removal of mes-aides-api logic.