### PR TITLE
Make project deprecated and include migration logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Deprecation notice - This project should no longer be used.
 ===========================================================
 
 > New versions pushed to easily migrate situations to the new format.
+> SEMVER is not enforced from 12.0.0 (and maybe before 🙂)
 
 A mapping interface between the [mes-aides](https://mes-aides.gouv.fr) [user interface](https://github.com/sgmap/mes-aides-ui) and the [OpenFisca](http://openfisca.fr) simulation engine.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+Deprecation notice - This project should no longer be used.
+===========================================================
+
+> New versions pushed to easily migrate situations to the new format.
+
 A mapping interface between the [mes-aides](https://mes-aides.gouv.fr) [user interface](https://github.com/sgmap/mes-aides-ui) and the [OpenFisca](http://openfisca.fr) simulation engine.
 
 > Une interface de lien entre l'interface utilisateur de mes-aides et OpenFisca.

--- a/lib/simulation/openfisca/mapping/foyerFiscal.js
+++ b/lib/simulation/openfisca/mapping/foyerFiscal.js
@@ -18,7 +18,7 @@ module.exports = {
     },
     rfr: {
         fn: function (situation) {
-            if (situation.ressourcesYearMoins2Captured) {
+            if (typeof situation.rfr == 'number') {
                 var anneeFiscaleN2 = moment(situation.dateDeValeur).subtract(2, 'years').year();
                 var result = {};
                 result[anneeFiscaleN2] = situation.rfr;

--- a/lib/simulation/openfisca/mapping/index.js
+++ b/lib/simulation/openfisca/mapping/index.js
@@ -170,24 +170,31 @@ var mapIndividus = exports.mapIndividus = function (situation) {
     });
 };
 
-var mapFamille = function(situation) {
-    var famille = buildOpenFiscaEntity(situation, familleSchema, situation);
+function aggregateIndividuRessources(situation) {
     var ressources = [];
+    var interruptedRessources = [];
     _.forEach(situation.individus, function(individu) {
         ressources = ressources.concat(individu.ressources);
+        interruptedRessources = interruptedRessources.concat(individu.interruptedRessources);
     });
-    applyRessources({ ressources: ressources }, famille, ressourcesMap.famille, situation);
+    return {
+        interruptedRessources: interruptedRessources,
+        ressources: ressources,
+    };
+}
+
+var mapFamille = exports.mapFamille = function(situation) {
+    var famille = buildOpenFiscaEntity(situation, familleSchema, situation);
+    applyRessources(aggregateIndividuRessources(situation), famille,
+        ressourcesMap.famille, situation);
 
     return famille;
 };
 
 var mapFoyerFiscal = exports.mapFoyerFiscal = function(situation) {
     var foyerFiscal = buildOpenFiscaEntity(situation, foyerSchema, situation);
-    var ressources = [];
-    _.forEach(situation.individus, function(individu) {
-        ressources = ressources.concat(individu.ressources);
-    });
-    applyRessources({ ressources: ressources }, foyerFiscal, ressourcesMap.foyerFiscal, situation);
+    applyRessources(aggregateIndividuRessources(situation), foyerFiscal,
+        ressourcesMap.foyerFiscal, situation);
 
     return foyerFiscal;
 };

--- a/lib/simulation/openfisca/mapping/index.js
+++ b/lib/simulation/openfisca/mapping/index.js
@@ -35,9 +35,32 @@ var getPeriods = function(dateDeValeur) {
     };
 };
 
-var applyRessources = function(mesAidesEntity, openfiscaEntity, mappingSchema, situation) {
+function aggregateIndividuRessources(individus, periods) {
+    var ressources = [];
+    var interruptedRessources = [];
+    _.forEach(individus, function(individu) {
+        var ressourcesByType = _.groupBy(individu.ressources, 'type');
+        ressources = ressources.concat(individu.ressources);
+        Object.keys(ressourcesByType).forEach(function(srcKey) {
+            var ressourceLastMonth = _.find(ressourcesByType[srcKey], {periode : periods['1MonthsAgo']});
+            if (ressourceLastMonth && ressourceLastMonth.montant && !_.includes(individu.interruptedRessources, srcKey)) {
+                ressources.push(Object.assign({}, ressourceLastMonth, {
+                    periode: periods.thisMonth
+                }));
+            }
+        });
+    });
+
+    return {
+        interruptedRessources: interruptedRessources,
+        ressources: ressources,
+    };
+}
+
+var applyRessources = function(ressourcesContainer, openfiscaEntity, mappingSchema, situation) {
     var dateDeValeur = situation.dateDeValeur;
     var periods = getPeriods(dateDeValeur);
+    var mesAidesEntity = aggregateIndividuRessources(ressourcesContainer, periods);
     var ressourcesByType = _.groupBy(mesAidesEntity.ressources, 'type');
 
     _.forEach(mappingSchema, function(definitions, openfiscaKey) {
@@ -62,16 +85,6 @@ var applyRessources = function(mesAidesEntity, openfiscaEntity, mappingSchema, s
                         result[item.periode] += montant;
                     }
                 });
-
-                // Current month resources are given their latest value when not interrupted
-                var ressourceLastMonth = _.filter(ressourcesByType[srcKey], {periode : periods['1MonthsAgo']})
-                    .reduce(function(accum, value) {
-                        return accum + (value.montant || 0);
-                    }, 0);
-                if (ressourceLastMonth && !_.includes(mesAidesEntity.interruptedRessources, srcKey)) {
-                    result[periods.thisMonth] = result[periods.thisMonth] || 0;
-                    result[periods.thisMonth] += fn ? fn(ressourceLastMonth) : ressourceLastMonth;
-                }
 
                 // When they are not formally declared, resources of the année fiscale de référence are considered equal to latest 12 month resources 
                 if (! situation.ressourcesYearMoins2Captured) {
@@ -168,27 +181,14 @@ var mapIndividus = exports.mapIndividus = function (situation) {
             _.extend(individu, situation.patrimoine.toObject ? situation.patrimoine.toObject() : situation.patrimoine);
         }
         var openfiscaIndividu = buildOpenFiscaEntity(individu, individuSchema, situation);
-        applyRessources(individu, openfiscaIndividu, ressourcesMap.individu, situation);
+        applyRessources([individu], openfiscaIndividu, ressourcesMap.individu, situation);
         return openfiscaIndividu;
     });
 };
 
-function aggregateIndividuRessources(situation) {
-    var ressources = [];
-    var interruptedRessources = [];
-    _.forEach(situation.individus, function(individu) {
-        ressources = ressources.concat(individu.ressources);
-        interruptedRessources = interruptedRessources.concat(individu.interruptedRessources);
-    });
-    return {
-        interruptedRessources: interruptedRessources,
-        ressources: ressources,
-    };
-}
-
 var mapFamille = exports.mapFamille = function(situation) {
     var famille = buildOpenFiscaEntity(situation, familleSchema, situation);
-    applyRessources(aggregateIndividuRessources(situation), famille,
+    applyRessources(situation.individus, famille,
         ressourcesMap.famille, situation);
 
     return famille;
@@ -196,7 +196,7 @@ var mapFamille = exports.mapFamille = function(situation) {
 
 var mapFoyerFiscal = exports.mapFoyerFiscal = function(situation) {
     var foyerFiscal = buildOpenFiscaEntity(situation, foyerSchema, situation);
-    applyRessources(aggregateIndividuRessources(situation), foyerFiscal,
+    applyRessources(situation.individus, foyerFiscal,
         ressourcesMap.foyerFiscal, situation);
 
     return foyerFiscal;

--- a/lib/simulation/openfisca/mapping/index.js
+++ b/lib/simulation/openfisca/mapping/index.js
@@ -42,9 +42,14 @@ function aggregateIndividuRessources(individus, periods) {
         var ressourcesByType = _.groupBy(individu.ressources, 'type');
         ressources = ressources.concat(individu.ressources);
         Object.keys(ressourcesByType).forEach(function(srcKey) {
-            var ressourceLastMonth = _.find(ressourcesByType[srcKey], {periode : periods['1MonthsAgo']});
-            if (ressourceLastMonth && ressourceLastMonth.montant && !_.includes(individu.interruptedRessources, srcKey)) {
+            var ressourceLastMonth = _.filter(ressourcesByType[srcKey], {periode : periods['1MonthsAgo']})
+            .reduce(function(accum, ressource) {
+                return accum + (ressource.montant || 0);
+            }, 0);
+            if (ressourceLastMonth && !_.includes(individu.interruptedRessources, srcKey)) {
                 ressources.push(Object.assign({}, ressourceLastMonth, {
+                    type: srcKey,
+                    montant: ressourceLastMonth,
                     periode: periods.thisMonth
                 }));
             }

--- a/lib/simulation/openfisca/mapping/index.js
+++ b/lib/simulation/openfisca/mapping/index.js
@@ -80,7 +80,7 @@ var applyRessources = function(mesAidesEntity, openfiscaEntity, mappingSchema, s
                         result[periods.anneeFiscaleReference] = result[periods.lastYear];
                     } else {
                         var sumOverLast12Months = periods.last12Months.reduce(function(sum, periodObject) {
-                            return sum + result[periodObject];
+                            return sum + (result[periodObject] || 0);
                         }, 0);
                         if (sumOverLast12Months) {
                             periods.anneeFiscaleReference12Months.forEach(function(month) {

--- a/lib/simulation/openfisca/mapping/index.js
+++ b/lib/simulation/openfisca/mapping/index.js
@@ -64,10 +64,13 @@ var applyRessources = function(mesAidesEntity, openfiscaEntity, mappingSchema, s
                 });
 
                 // Current month resources are given their latest value when not interrupted
-                var ressourceLastMonth = _.find(ressourcesByType[srcKey], {periode : periods['1MonthsAgo']});
-                if (ressourceLastMonth && ressourceLastMonth.montant && !_.includes(mesAidesEntity.interruptedRessources, srcKey)) {
+                var ressourceLastMonth = _.filter(ressourcesByType[srcKey], {periode : periods['1MonthsAgo']})
+                    .reduce(function(accum, value) {
+                        return accum + (value.montant || 0);
+                    }, 0);
+                if (ressourceLastMonth && !_.includes(mesAidesEntity.interruptedRessources, srcKey)) {
                     result[periods.thisMonth] = result[periods.thisMonth] || 0;
-                    result[periods.thisMonth] += fn ? fn(ressourceLastMonth.montant) : ressourceLastMonth.montant;
+                    result[periods.thisMonth] += fn ? fn(ressourceLastMonth) : ressourceLastMonth;
                 }
 
                 // When they are not formally declared, resources of the année fiscale de référence are considered equal to latest 12 month resources 

--- a/lib/simulation/openfisca/mapping/individu.js
+++ b/lib/simulation/openfisca/mapping/individu.js
@@ -97,9 +97,9 @@ module.exports = {
     scolarite: {
         fn: function(individu) {
             var values = {
-                'inconnue': 0,
-                'college': 1,
-                'lycee': 2
+                'inconnue': 'Inconnue',
+                'college': 'Collège',
+                'lycee':'Lycée',
             };
             return values[individu.scolarite];
         }

--- a/lib/simulation/openfisca/mapping/individu.js
+++ b/lib/simulation/openfisca/mapping/individu.js
@@ -25,12 +25,15 @@ module.exports = {
     },
     statut_marital: {
         src: 'statutMarital',
-        values: {
-            seul: 'Célibataire', // Enum value 2 in OpenFisca
-            mariage: 'Marié',// Enum value 1 in OpenFisca
-            pacs: 'Pacsé', // Enum value 5 in OpenFisca
-            union_libre: 'Célibataire', // Enum value 2 in OpenFisca
-        }
+        fn: function (statutMarital, individu) {
+            var values = {
+                seul: 'Célibataire', // Enum value 2 in OpenFisca
+                mariage: 'Marié',// Enum value 1 in OpenFisca
+                pacs: 'Pacsé', // Enum value 5 in OpenFisca
+                union_libre: 'Célibataire', // Enum value 2 in OpenFisca
+            };
+            return values[statutMarital] || (individu.role == 'demandeur' && 'Célibataire') || undefined;
+        },
     },
     id: {
         src: 'id',

--- a/lib/simulation/openfisca/mapping/individu.js
+++ b/lib/simulation/openfisca/mapping/individu.js
@@ -82,12 +82,6 @@ module.exports = {
         }
     },
     perte_autonomie: 'perteAutonomie',
-    etudiant: {
-        src: 'specificSituations',
-        fn: function(specificSituations) {
-            return specificSituations.indexOf('etudiant') >= 0;
-        }
-    },
     boursier: {
         fn: function(individu) {
             return individu.boursier || individu.echelonBourse >= 0;  // backward compatibility for boursier; cannot write a migration because the exact echelon is not known

--- a/lib/simulation/openfisca/mapping/individu.js
+++ b/lib/simulation/openfisca/mapping/individu.js
@@ -47,9 +47,9 @@ module.exports = {
         fn: function(value) {
             var returnValue;
             _.forEach({
-                demandeur_emploi: 1,
-                etudiant: 2,
-                retraite: 3
+                demandeur_emploi: 'Chômeur',
+                etudiant: 'Étudiant, élève',
+                retraite: 'Retraité',
             }, function(situationIndex, situation) {
                 if (value.indexOf(situation) >= 0) {
                     returnValue = situationIndex;

--- a/lib/simulation/openfisca/mapping/individu.js
+++ b/lib/simulation/openfisca/mapping/individu.js
@@ -26,10 +26,10 @@ module.exports = {
     statut_marital: {
         src: 'statutMarital',
         values: {
-            seul: 2,
-            mariage: 1,
-            pacs: 5,
-            union_libre: 2
+            seul: 'Célibataire', // Enum value 2 in OpenFisca
+            mariage: 'Marié',// Enum value 1 in OpenFisca
+            pacs: 'Pacsé', // Enum value 5 in OpenFisca
+            union_libre: 'Célibataire', // Enum value 2 in OpenFisca
         }
     },
     id: {

--- a/lib/simulation/openfisca/mapping/menage.js
+++ b/lib/simulation/openfisca/mapping/menage.js
@@ -45,12 +45,10 @@ module.exports = {
         }
     },
     loyer: {
-        fn: function (situation) { return situation.logement.loyer; },
-        round: true
+        fn: function (situation) { return situation.logement.loyer; }
     },
     charges_locatives: {
-        fn: function (situation) { return situation.logement.charges; },
-        round: true
+        fn: function (situation) { return situation.logement.charges; }
     },
     depcom: {
         fn: function (situation) { return situation.logement.adresse.codeInsee || null; }

--- a/lib/simulation/openfisca/mapping/menage.js
+++ b/lib/simulation/openfisca/mapping/menage.js
@@ -58,12 +58,12 @@ module.exports = {
     },
     coloc: {
         fn: function (situation) {
-            return situation.logement.type == 'locataire' && situation.logement.colocation;
+            return (situation.logement.type == 'locataire' && situation.logement.colocation) || situation.logement.colocation;
         }
     },
     logement_chambre: {
         fn: function (situation) {
-            return situation.logement.type == 'locataire' && situation.logement.isChambre;
+            return (situation.logement.type == 'locataire' && situation.logement.isChambre) || situation.logement.isChambre;
         }
     },
 };

--- a/lib/simulation/openfisca/mapping/menage.js
+++ b/lib/simulation/openfisca/mapping/menage.js
@@ -22,13 +22,13 @@ module.exports = {
     statut_occupation_logement: {
         fn: function(situation) {
             var statusOccupationMap = {
-                'proprietaireprimoaccedant': 1,
-                'proprietaire': 2,
-                'locatairenonmeuble': 4,
-                'locatairemeublehotel': 5,
-                'heberge': 6,
-                'locatairefoyer': 7,
-                'sansDomicile' : 8
+                'proprietaireprimoaccedant': 'Accédant à la propriété',
+                'proprietaire': 'Propriétaire (non accédant) du logement',
+                'locatairenonmeuble': 'Locataire ou sous-locataire d‘un logement loué vide non-HLM',
+                'locatairemeublehotel': 'Locataire ou sous-locataire d‘un logement loué meublé ou d‘une chambre d‘hôtel',
+                'heberge': 'Logé gratuitement par des parents, des amis ou l‘employeur',
+                'locatairefoyer': 'Locataire d‘un foyer (résidence universitaire, maison de retraite, foyer de jeune travailleur, résidence sociale...)',
+                'sansDomicile' : 'Sans domicile stable'
             };
             var logement = situation.logement;
             var type = logement.type;

--- a/lib/simulation/openfisca/prestations.js
+++ b/lib/simulation/openfisca/prestations.js
@@ -11,15 +11,6 @@ module.exports = {
     cmu_c: {
         type: Boolean
     },
-    apl: {
-        type: Number
-    },
-    als: {
-        type: Number
-    },
-    alf: {
-        type: Number
-    },
     aide_logement: {
         type: Number
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "sgmap-mes-aides-api",
   "description": "mes-aides.gouv.fr REST API",
-  "version": "11.0.1",
+  "version": "12.0.0",
   "license": "AGPL-3.0",
   "repository": {
     "type": "git",

--- a/test/openfisca/mapping/index.js
+++ b/test/openfisca/mapping/index.js
@@ -20,15 +20,22 @@ describe('Ressources', function () {
                             periode: '2015-02',
                             type: 'revenus_stage_formation_pro',
                             montant: 300
+                        },
+                        {
+                            periode: '2015-02',
+                            type: 'paje_clca',
+                            montant: 42
                         }
                     ],
-                    interruptedRessources: ['indemnites_stage'],
+                    interruptedRessources: ['indemnites_stage', 'paje_clca'],
                     specificSituations: [],
                 }
-            ]
+            ],
+            logement: {},
         };
 
         var individu = mapping.mapIndividus(situation)[0];
+        var famille = mapping.mapFamille(situation);
 
         it('devrait copier les ressources encore perçues sur le mois courant', function () {
             individu.revenus_stage_formation_pro.should.have.ownProperty('2015-03');
@@ -37,6 +44,15 @@ describe('Ressources', function () {
 
         it('ne devrait pas copier les ressources dont la perception est interrompue sur le mois courant', function () {
             individu.indemnites_stage.should.not.have.ownProperty('2015-03');
+        });
+
+        it('devrait afficher paje_clca pour le mois courant', function() {
+            famille.paje_clca.should.have.ownProperty('2015-02');
+            famille.paje_clca['2015-02'].should.equal(42);
+        });
+
+        it('ne devrait pas prolonger paje_clca', function() {
+            famille.paje_clca.should.not.have.ownProperty('2015-03');
         });
 
     });


### PR DESCRIPTION
As long as situations haven't been migrated, mes-aides-ui should depends on that project to validate the migration process.

This project should not be used apart for that purpose.